### PR TITLE
Additional info for API key generation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@
 5. Check the following permissions:
    - Create an invoice (btcpay.store.cancreateinvoice)
    - View your stores (btcpay.store.canviewstoresettings)
-6. Click on [Generate API Key]
-7. Copy the generated API Key to your BTCPay Server payment profile settings form
+6. Below the permissions click on [Select specific stores] and select the store created already (this ensures the API key is restricted to this single store)
+7. Click on [Generate API Key]
+8. Copy the generated API Key to your BTCPay Server payment profile settings form
 
 ### Setup Webhook
 1. Go to your BTCPay Server


### PR DESCRIPTION
When creating the API key and set permissions you should limit the scope of them to specific stores otherwise the API key will be valid for all the stores you created under your account.

For context see the docs here https://docs.btcpayserver.org/WooCommerce/#22-connect-by-manually-creating-the-api-key-and-permissions